### PR TITLE
Fix callback_url because callback_path already includes script_name in omniauth 2.0

### DIFF
--- a/lib/omniauth/strategies/microsoft_office365.rb
+++ b/lib/omniauth/strategies/microsoft_office365.rb
@@ -56,7 +56,7 @@ module OmniAuth
       private
 
       def callback_url
-        options[:redirect_uri] || (full_host + script_name + callback_path)
+        options[:redirect_uri] || (full_host + callback_path)
       end
 
       def avatar_file

--- a/omniauth-microsoft-office365.gemspec
+++ b/omniauth-microsoft-office365.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.1'
 
-  spec.add_runtime_dependency "omniauth"
+  spec.add_runtime_dependency "omniauth", ">= 2.0"
   spec.add_runtime_dependency "omniauth-oauth2"
 
   spec.add_development_dependency "bundler", ">= 1.6"


### PR DESCRIPTION
See https://github.com/omniauth/omniauth/commit/c606a00798a7f516c37c67a708864f9a3eb9f796#diff-c2f37e7010d83348d856f2e436efbfc2a93e396b200d1f6f8821ced735463ce8R480
and https://github.com/omniauth/omniauth/commit/c606a00798a7f516c37c67a708864f9a3eb9f796#diff-c2f37e7010d83348d856f2e436efbfc2a93e396b200d1f6f8821ced735463ce8R437
 for the commit that added script_name to the callback_path.